### PR TITLE
Try to fix folder rename issue on Windows

### DIFF
--- a/src/pure-get-edits.ts
+++ b/src/pure-get-edits.ts
@@ -161,7 +161,7 @@ function* handleRenameEvent(
       );
 
       const isLinkToFileInRenamedFolder = absoluteTarget.startsWith(
-        pathBefore + "/"
+        pathBefore + path.sep
       );
 
       const isLinkToMovedFile = absoluteTarget === pathBefore;


### PR DESCRIPTION
Try to fix #6. 

And it works now:

<details>
<summary>Details</summary>

![demo](https://user-images.githubusercontent.com/51501079/113464481-9b1b6580-945f-11eb-81d3-34050866aac8.gif)

</details>