### PR TITLE
fix: path containing the backslash is not updated

### DIFF
--- a/src/__tests__/pure-get-edits.test.ts
+++ b/src/__tests__/pure-get-edits.test.ts
@@ -598,6 +598,28 @@ describe("pureGetEdits", () => {
         ],
       });
     });
+
+    it("handles markdown links with windows style paths", () => {
+      testRename({
+        payload: {
+          pathBefore: "sub/test.gif",
+          pathAfter: "sub/test1.gif",
+        },
+        markdownFiles: [
+          {
+            path: "README.md",
+            content: "![](sub\\test.gif)",
+          },
+        ],
+        expectedEdits: [
+          {
+            path: "README.md",
+            range: "0:4-0:16",
+            newText: "sub/test1.gif",
+          },
+        ],
+      });
+    });
   });
 
   describe("save", () => {

--- a/src/pure-get-edits.ts
+++ b/src/pure-get-edits.ts
@@ -272,7 +272,8 @@ function* getMatchingLinks(regex: RegExp, fileContent: string | undefined) {
   regex.lastIndex = 0;
   let match: RegExpExecArray | null;
   while ((match = regex.exec(fileContent)) !== null) {
-    const [_, prefix, target] = match;
+    let [_, prefix, target] = match;
+    target = windowsToPosix(target);
     const index = match.index + prefix.length;
     const lines = fileContent.substring(0, index).split("\n");
     const line = lines.length - 1;


### PR DESCRIPTION
Hi👋! @mathiassoeholm 

I found that the path containing the backslash is not updated：

<details>
<summary>Before</summary>

![before](https://user-images.githubusercontent.com/51501079/123838616-c1598000-d93e-11eb-8f98-a9438930b1ce.gif)

</details>

So I changed the code a little bit, seems to be helpful：

<details>
<summary>After</summary>

![after](https://user-images.githubusercontent.com/51501079/123838744-e6e68980-d93e-11eb-9686-96604e7806e2.gif)

</details>