### PR TITLE
add option to disable confirmation prompt

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,11 @@
           "type": "array",
           "default": [],
           "description": "Array of glob patterns used to include specific folders and files. If the array is empty, everything will be included, unless specified by exclude."
+        },
+        "markdownLinkUpdater.disableConfirmationPrompt": {
+          "type": "boolean",
+          "default": false,
+          "description": "Disable confirmation prompt when updating a large number of links at once."
         }
       }
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,9 @@ const config = {
   get include() {
     return getConfig().get<string[]>("include", []);
   },
+  get disableConfirmationPrompt() {
+    return getConfig().get<boolean>("disableConfirmationPrompt", false);
+  },
 };
 
 function getOptions(targetFile: Path): Options {

--- a/src/execute-edits.ts
+++ b/src/execute-edits.ts
@@ -1,6 +1,7 @@
 import { pathExistsSync } from "fs-extra";
 import { Position, Range, Uri, window, workspace, WorkspaceEdit } from "vscode";
 import { Edit } from "./models";
+import { config } from "./config";
 
 async function executeEdits(edits: Edit[]) {
   edits = edits.filter(
@@ -9,7 +10,7 @@ async function executeEdits(edits: Edit[]) {
   );
 
   const shouldExecute =
-    edits.length > 5
+    edits.length > 5 && !config.disableConfirmationPrompt
       ? await window.showInformationMessage(
           `Update ${edits.length} Markdown links?`,
           { modal: true },


### PR DESCRIPTION
The need to confirm every single file can be quite annoying when you want to rename a large number of files (hundreds in my case)