### PR TITLE
Add test showing section issue

### DIFF
--- a/src/__tests__/pure-get-edits.test.ts
+++ b/src/__tests__/pure-get-edits.test.ts
@@ -752,6 +752,34 @@ describe("pureGetEdits", () => {
         ],
       });
     });
+
+    it("updates files linking to a section in the moved file in a table", () => {
+      testRename({
+        payload: {
+          pathBefore: "folder/file-2.md",
+          pathAfter: "folder/newfolder/file-2.md",
+        },
+        markdownFiles: [
+          {
+            path: "file-1.md",
+            content:
+              "# File 1\n| a link [link to file-2](folder/file-2.md#heading) | is \"here\" |",
+          },
+          {
+            path: "folder/newfolder/file-2.md",
+            content: "# Just some markdown file\n## Heading",
+          },
+        ],
+        expectedEdits: [
+          {
+            path: "file-1.md",
+            range: "1:26-1:50",
+            newText: "folder/newfolder/file-2.md#heading",
+          },
+        ],
+      });
+    });
+
   });
 
   describe("save", () => {


### PR DESCRIPTION
This test fails with:

```
● pureGetEdits › rename › updates files linking to a section in the moved file in a table

    expect(received).toEqual(expected) // deep equality

    - Expected  - 2
    + Received  + 2

    @@ -1,12 +1,12 @@
      Array [
        Object {
    -     "newText": "folder/newfolder/file-2.md#heading",
    +     "newText": "folder/newfolder/file-2.md",
          "path": "file-1.md",
          "range": Object {
            "end": Object {
    -         "character": 50,
    +         "character": 42,
              "line": 1,
            },
            "start": Object {
              "character": 26,
              "line": 1,

      30 |       const edits = pureGetEdits(event, markdownFiles, options);
      31 | 
    > 32 |       expect(edits).toEqual(
         |                     ^
      33 |         expectedEdits.map((e) => {
      34 |           const [start, end] = e.range.split("-");
      35 |           const [startLine, startCharacter] = start.split(":");

      at testRename (src/__tests__/pure-get-edits.test.ts:32:21)
      at Object.<anonymous> (src/__tests__/pure-get-edits.test.ts:757:7)
```

Will raise issue shortly.