### PR TITLE
Update path inside files of a moved folder

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,7 +23,8 @@
         "--disable-extensions"
       ],
       "outFiles": ["${workspaceFolder}/out/test/**/*.js"],
-      "preLaunchTask": "${defaultBuildTask}"
+      "preLaunchTask": "${defaultBuildTask}",
+      "outputCapture": "console"
     }
   ]
 }

--- a/src/pure-get-edits.ts
+++ b/src/pure-get-edits.ts
@@ -323,4 +323,4 @@ const windowsToPosix = (path: string) => {
   return path.replace(/\\/g, "/");
 };
 
-export { pureGetEdits, Options };
+export { pureGetEdits, Options, windowsToPosix };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "commonjs",
     "target": "es6",
     "outDir": "out",
-    "lib": ["es6"],
+    "lib": ["es6", "dom"],
     "sourceMap": true,
     "esModuleInterop": true,
     "rootDir": "src",


### PR DESCRIPTION
Added the feature:
#33 

While this PR gets accepted, you can access this extension via the release section from my fork: https://github.com/MasterHansCoding/mlu-main-UpdateLinksInsideMovedFile